### PR TITLE
Use the same Python version as YCM

### DIFF
--- a/autoload/dyevim.vim
+++ b/autoload/dyevim.vim
@@ -26,8 +26,8 @@ set cpo&vim
 
 let s:script_folder_path = escape( expand( '<sfile>:p:h' ), '\' )
 let s:current_filetype = ''
-let s:py = has('python') ? "py" : "py3"
-let s:python_eof = has('python') ? "python << EOF" : "python3 << EOF"
+let s:py = has('python3') ? "py3" : "py"
+let s:python_eof = has('python3') ? "python3 << EOF" : "python << EOF"
 
 function! dyevim#Enable()
     if &diff


### PR DESCRIPTION
When Python 2 and 3 are available, we need to use the version that is
used by YCM to be able to access ycm_state. This commit adopts the
version detection logic of YCM to ensure that we use the right version.

Fixes #7.


See 
https://github.com/Valloric/YouCompleteMe/blob/e4c6750a4b3df943deca69195a671b781d16d680/autoload/youcompleteme.vim#L65 .
It would be easier to copy this code but it's under GPL3.